### PR TITLE
Title not pulling through from PR

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@
 
   function findPullRequestSummary() {
     // relies on the first task-list element being the PR summary
-    var el = document.querySelector("task-lists");
+    const el = document.querySelector("task-lists");
     if (!el) {
       console.error("Can't determine PR summary: no 'task-list' elements found");
       return "- edit me please -";

--- a/main.js
+++ b/main.js
@@ -38,9 +38,9 @@
   }
 
   function findPullRequestTitle() {
-    const el = document.querySelector("span.js-issue-title");
+    const el = document.querySelector("bdi.js-issue-title");
     if (!el) {
-      console.error("Can't determine PR title: no 'span.js-issue-title' element found");
+      console.error("Can't determine PR title: no 'bdi.js-issue-title' element found");
       return "New release";
     }
     return el.textContent.trim();

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "PR2R",
   "version": "1.2",
   "description": "Adds a button to GitHub Pull Request pages to create a Release from the current Pull Request",


### PR DESCRIPTION
Title cannot be found because it's been changed from `span` to `bdi`.

Also went through the Chrome extension checklist to upgrade to v3 and updated. Release to the web store should be possible now.